### PR TITLE
Fix issue with dead keys

### DIFF
--- a/src/api/x11/input.rs
+++ b/src/api/x11/input.rs
@@ -129,10 +129,15 @@ impl XInputEventHandler {
 
         let mut translated_events = Vec::new();
 
+        let raw_ev: *mut ffi::XKeyEvent = event;
+        let filter = unsafe { (self.display.xlib.XFilterEvent)(mem::transmute(raw_ev), self.window) };
+
+        if filter != 0 {
+            return translated_events;
+        }
+
         let state;
         if event.type_ == ffi::KeyPress {
-            let raw_ev: *mut ffi::XKeyEvent = event;
-            unsafe { (self.display.xlib.XFilterEvent)(mem::transmute(raw_ev), self.window) };
             state = Pressed;
         } else {
             state = Released;

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -240,7 +240,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     return Some(Refresh);
                 },
 
-                ffi::KeyPress | ffi::KeyRelease => {
+                ffi::KeyPress => {
                     let mut event: &mut ffi::XKeyEvent = unsafe { mem::transmute(&mut xev) };
                     let events = self.window.input_handler.lock().unwrap().translate_key_event(&mut event);
                     for event in events {


### PR DESCRIPTION
Glutin had two issues while handling keyboard events. The first one was caused by passing KeyRelease events to Xutf8LookupString, which is wrong according to the docs [1].

On the second issue Glutin was calling XFilterEvent but not using its return. This function should advice client code to skip a event if it was already handled [2]. This is essential for dead keys to work, since the dead key itself should neither print nor do anything at all. To fix this issue we now save XFilterEvent return and, if it is true, exit the function early.

[1] https://www.x.org/archive/current/doc/man/man3/XmbLookupString.3.xhtml
[2] https://www.x.org/archive/current/doc/man/man3/XFilterEvent.3.xhtml